### PR TITLE
Fix custom attribute bug

### DIFF
--- a/JsonSettings.Library/JsonProtectAttribute.cs
+++ b/JsonSettings.Library/JsonProtectAttribute.cs
@@ -33,6 +33,10 @@ namespace JsonSettings
 
                 // Obtain any member that matches case sensitive. Will only return 1 match anyway.
                 MemberInfo fi = type.GetMember(prop.UnderlyingName).FirstOrDefault();
+
+                if (fi.GetCustomAttribute<JsonIgnoreAttribute>() != null)
+                    continue;
+
                 var attr = fi.GetCustomAttribute<JsonProtectAttribute>();
                 if (attr != null)
                     prop.ValueProvider = new ProtectedDataValueProvider(pi, attr.Scope);

--- a/JsonSettings.Library/JsonProtectAttribute.cs
+++ b/JsonSettings.Library/JsonProtectAttribute.cs
@@ -30,16 +30,23 @@ namespace JsonSettings
             foreach (JsonProperty prop in props.Where(p => p.PropertyType.Equals(typeof(string))))
             {
                 PropertyInfo pi = type.GetProperty(prop.UnderlyingName);
-
-                // Obtain any member that matches case sensitive. Will only return 1 match anyway.
-                MemberInfo fi = type.GetMember(prop.UnderlyingName).FirstOrDefault();
-
-                if (fi.GetCustomAttribute<JsonIgnoreAttribute>() != null)
+                // Skip if member is not a property.
+                if (pi is null)
+                {
                     continue;
+                }
 
-                var attr = fi.GetCustomAttribute<JsonProtectAttribute>();
+                // Skip if JsonIgnore.
+                if (pi.GetCustomAttribute<JsonIgnoreAttribute>() != null)
+                {
+                    continue;
+                }
+
+                var attr = pi.GetCustomAttribute<JsonProtectAttribute>();
                 if (attr != null)
+                {
                     prop.ValueProvider = new ProtectedDataValueProvider(pi, attr.Scope);
+                }
             }
 
             return props;

--- a/JsonSettings.Library/JsonProtectAttribute.cs
+++ b/JsonSettings.Library/JsonProtectAttribute.cs
@@ -30,8 +30,12 @@ namespace JsonSettings
             foreach (JsonProperty prop in props.Where(p => p.PropertyType.Equals(typeof(string))))
             {
                 PropertyInfo pi = type.GetProperty(prop.UnderlyingName);
-                var attr = pi.GetCustomAttribute<JsonProtectAttribute>();
-                if (attr != null) prop.ValueProvider = new ProtectedDataValueProvider(pi, attr.Scope);
+
+                // Obtain any member that matches case sensitive. Will only return 1 match anyway.
+                MemberInfo fi = type.GetMember(prop.UnderlyingName).FirstOrDefault();
+                var attr = fi.GetCustomAttribute<JsonProtectAttribute>();
+                if (attr != null)
+                    prop.ValueProvider = new ProtectedDataValueProvider(pi, attr.Scope);
             }
 
             return props;


### PR DESCRIPTION
The base method `IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)` from Newtonsoft.Json fails to recognize the `MemberSerialization.OptOut` setting and returns public fields that are marked as `[JsonIgnore]`.

This pull request fixes two issues with the `JsonSettings` override of the method.

1. Fields are returned as part of the CreateProperties base method. This changes the method of obtaining the MemberInfo to get the reflection of the CustomAttribute.
2. This fixes the JsonIgnoreAttribute not implemented correctly by Newtonsoft.Json. (see also https://github.com/JamesNK/Newtonsoft.Json/issues/2968)