### PR TITLE
Change targets to also support Net Framework (and NetStandard2.0)

### DIFF
--- a/JsonSettings.Library/JsonSettings.Library.csproj
+++ b/JsonSettings.Library/JsonSettings.Library.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>1.2.0</Version>
     <Authors>Adam O'Neil</Authors>
     <Description>Lightweight json-based app and user settings, with support for DPAPI encryption</Description>
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/adamosoftware/JsonSettings</RepositoryUrl>
     <PackageTags>json settings encryption dpapi</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>Updated Json.NET package, Test project now targets .NET8</PackageReleaseNotes>
+    <PackageReleaseNotes>Targeting NetStandard2.0 although encryption only works on windows platforms</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/adamosoftware/JsonSettings</PackageProjectUrl>
   </PropertyGroup>

--- a/JsonSettings.Test/JsonSettings.Test.csproj
+++ b/JsonSettings.Test/JsonSettings.Test.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
-
+    <TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
+    <LangVersion>11.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Make the main project target netstandard2.0 again. Encryption requires the windows platform, but the other features should work cross-platform.
Make the test project target net8.0-windows and net48 (although it should work back to net462).

