### PR TITLE
Add Load JsonSerializerSettings delegate

### DIFF
--- a/JsonSettings.Library/JsonFile.cs
+++ b/JsonSettings.Library/JsonFile.cs
@@ -56,7 +56,7 @@ namespace JsonSettings
             return Load<T>(fileName);
         }
 
-        public static T Load<T>(string fileName, Func<T> ifNotExists = null, EventHandler<Newtonsoft.Json.Serialization.ErrorEventArgs> error = null)
+        public static T Load<T>(string fileName, Func<T> ifNotExists = null, Action<JsonSerializerSettings> updateSettings = null, EventHandler<Newtonsoft.Json.Serialization.ErrorEventArgs> error = null)
         {
             if (!File.Exists(fileName) && ifNotExists != null) return ifNotExists.Invoke();
 
@@ -67,6 +67,8 @@ namespace JsonSettings
                     Error = error,
                     ContractResolver = new DataProtectionResolver()
                 };
+
+                updateSettings?.Invoke(settings);
 
                 string json = reader.ReadToEnd();
                 if (!string.IsNullOrEmpty(json) && !json.Equals("null"))
@@ -84,7 +86,7 @@ namespace JsonSettings
             return await LoadAsync<T>(fileName);
         }
 
-        public async static Task<T> LoadAsync<T>(string fileName, Func<T> ifNotExists = null, EventHandler<Newtonsoft.Json.Serialization.ErrorEventArgs> error = null)
+        public async static Task<T> LoadAsync<T>(string fileName, Func<T> ifNotExists = null, Action<JsonSerializerSettings> updateSettings = null, EventHandler<Newtonsoft.Json.Serialization.ErrorEventArgs> error = null)
         {
             if (!File.Exists(fileName) && ifNotExists != null) return ifNotExists.Invoke();
 
@@ -95,6 +97,8 @@ namespace JsonSettings
                     Error = error,
                     ContractResolver = new DataProtectionResolver()
                 };
+
+                updateSettings?.Invoke(settings);
 
                 string json = await reader.ReadToEndAsync();
                 if (!json.Equals(string.Empty))

--- a/JsonSettings.Library/SettingsBase.cs
+++ b/JsonSettings.Library/SettingsBase.cs
@@ -22,13 +22,13 @@ namespace JsonSettings.Library
 
         protected virtual void Initialize() { }
 
-        public static T Load<T>(EventHandler<Newtonsoft.Json.Serialization.ErrorEventArgs> error = null) where T : SettingsBase, new()
+        public static T Load<T>(Action<JsonSerializerSettings> updateSettings = null, EventHandler<Newtonsoft.Json.Serialization.ErrorEventArgs> error = null) where T : SettingsBase, new()
         {
             T result = new T();
 
             if (File.Exists(result.Filename))
             {
-                result = JsonFile.Load<T>(result.Filename, error: error) ?? result;
+                result = JsonFile.Load<T>(result.Filename, updateSettings: updateSettings, error: error) ?? result;
             }
 
             result.Initialize();


### PR DESCRIPTION
## Proposed change
Add JsonSerializerSettings delegate to update the parameters for loading a Json file.

Should we also remove `EventHandler<Newtonsoft.Json.Serialization.ErrorEventArgs> error = null` from the methods as they can be set via the delegate? Do you want the README to be updated with example use case of implementing a delegate and the scenario? Any UnitTests required for these change? This is essentially independent from the package as it is a delegate.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
#### Testing
- [ ] The code change is UX and functionally tested and works locally. __(Non-unit testing)__
- [ ] Local unit/integration/system tests pass.
- [ ] Tests have been added to verify that the new code works.

#### Documentation
- [ ] Documentation added/updated